### PR TITLE
add *.kubeconfig to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 manifests/_output
 *.env
 redis-ha/_output
+**/*.kubeconfig


### PR DESCRIPTION
added `**/*.kubeconfig` line to the `.gitignore` to avoid adding any *.kubeconfig file to the repo